### PR TITLE
🔨 Fixes the stack order of the mobile navbar when its open. 🔨

### DIFF
--- a/src/components/navbar/style.css
+++ b/src/components/navbar/style.css
@@ -77,6 +77,7 @@
   backdrop-filter: blur(4px);
   padding: 24px;
   animation: fadeIn 0.3s ease-in-out;
+  z-index: 99999;
 
   .mobile-navbar-items {
     width: 100%;


### PR DESCRIPTION
### Description
- The logo is overlaying the mobile navbar when its open, this PR fixes it stack order to maintain the navbar as higher order.
---
<sub>THEN</sub>
![{E64272DB-B406-4649-81B9-08D70B27165D}](https://github.com/user-attachments/assets/35b8a7e2-e858-4220-8be6-a18d101b0734)


<sub>NOW</sub>
![{D2E800E1-54DC-411B-A3AA-97A8B5E8EF58}](https://github.com/user-attachments/assets/e810c18a-1038-4d30-af23-70e6ca8f8468)
